### PR TITLE
Send ipmitool SIGTERM instead of SIGKILL

### DIFF
--- a/ipmitool.go
+++ b/ipmitool.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/kr/pty"
 )
@@ -24,7 +25,7 @@ type ipmiProcess struct {
 }
 
 func (p *ipmiProcess) Close() error {
-	p.proc.Kill()
+	p.proc.Signal(syscall.SIGTERM)
 	p.proc.Wait()
 	return p.ReadCloser.Close()
 }


### PR DESCRIPTION
@naved001, can you try this to see if it behaves any differently? I'm hypothesizing that there is some cleanup work to do, and normally ipmtool does that before exiting, but because Kill() just sends SIGKILL, it doesn't have the opportunity.