### PR TITLE
Get rid of version mechanism.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ Notes:
 * The token in a successful response is to be used to authenticate
   non-admin operations, described below.
 
+### Invalidating a console token
+
+`DELETE /node/{node_id}/token`
+
+Notes:
+
+* This operation always returns a successful error code (assuming the
+  user authenticates correctly); if there is no existing valid token for
+  the node, this is a no-op.
+
 ## Non-admin operations
 
 ### Viewing the console

--- a/README.md
+++ b/README.md
@@ -69,60 +69,21 @@ Notes:
 * The fields in the `info` field are passed directly to ipmitool
 * If the node already exists, the information will be updated.
 
-### Checking the version of a node
+### Unregistering a node
 
-`GET /node/{node_id}/version`
+`DELETE /node/{node_id}`.
 
-Response body
+Notes:
 
-```json
-{
-    "version": 7
-}
-```
-
-Get the current version of a node.
-
-### Updating the version of a node
-
-`PUT /node/{node_id}/version`
-
-Request body:
-
-```json
-{
-    "version": 7
-}
-```
-
-Update the version number of the node, disconnecting any existing
-clients and invalidating any tokens.  The version number in the request
-body must be `$current_version_number + 1`; otherwise an error will be
-returned and the version will not be updated. Returns the updated
-version number. (which should be the same as in the body of the
-request).
-
-Response body:
-
-```json
-{
-    "version": 7
-}
-```
+* This implicitly invalidates any active tokens.
 
 ### Getting a new console token
 
 Request body:
 
-`POST /node/{node_id}/console-endpoints`
+`POST /node/{node_id}/token`
 
-```json
-{
-    "version": 3
-}
-```
-
-Response body (success):
+Response body:
 
 ```json
 {
@@ -130,23 +91,12 @@ Response body (success):
 }
 ```
 
-Response body (failure):
-
-```json
-{
-    "version": 4
-}
-```
-
 Notes:
 
-* The version in the request must match the current version of the node.
-* The token in a successful response is to be used to view the console.
-* In the case of a version-mismatch, the response body will return the
-  correct version.
+* The token in a successful response is to be used to authenticate
+  non-admin operations, described below.
 
 ## Non-admin operations
-
 
 ### Viewing the console
 
@@ -157,17 +107,6 @@ Notes:
 * The `<token>` is fetched as described above
 * Data from the console will begin streaming from the response body.
 
-# Extras
-
-* If the `-dummydialer` cli option is passed, rather than launching
-  ipmitool, the server will simply open a tcp connection to the
-  "addr" specified (in which case it should be of the form required
-  by [net.Dial][net.Dial]. This is useful for experimentation.
-* There's some preliminary work on supporting a database, but it isn't
-  actually used. The `-dbpath` argument sets the path, but the db won't
-  be used beyond initializing a schema.
-
 [net.Dial]: https://golang.org/pkg/net/#Dial
-
 [travis]: https://travis-ci.org/zenhack/console-service
 [travis-img]: https://travis-ci.org/zenhack/console-service.svg?branch=master

--- a/daemon.go
+++ b/daemon.go
@@ -38,7 +38,7 @@ func (d *Daemon) SetNode(label string, info []byte) error {
 
 	_, err := d.state.GetNode(label)
 	if err == nil {
-		// The node already exists; delete it before (re)createing it.
+		// The node already exists; delete it before (re)creating it.
 		if err = d.state.DeleteNode(label); err != nil {
 			return err
 		}

--- a/http.go
+++ b/http.go
@@ -104,7 +104,7 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 			relayError(w, "daemon.DeleteNode()", daemon.DeleteNode(nodeId(req)))
 		})
 
-	adminR.Methods("POST").Path("/node/{node_id}/console-endpoints").
+	adminR.Methods("POST").Path("/node/{node_id}/token").
 		HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			token, err := daemon.GetNodeToken(nodeId(req))
 			if err != nil {

--- a/node.go
+++ b/node.go
@@ -10,16 +10,14 @@ import (
 
 // Information about a node
 type Node struct {
-	Version      uint64             // The node's version; incremented on each change.
 	ConnInfo     []byte             // Connection info for this node's OBM.
 	ObmCancel    context.CancelFunc // stop the OBM
 	OBM          driver.OBM         // OBM for this node.
 	CurrentToken Token              // Token for regular user operations.
 }
 
-// Returns a new node with the given driver information, at version 0, with no
-// valid token.
-func NewNode(d driver.Driver, info []byte, version uint64) (*Node, error) {
+// Returns a new node with the given driver information, with no valid token.
+func NewNode(d driver.Driver, info []byte) (*Node, error) {
 	obm, err := d.GetOBM(info)
 	if err != nil {
 		return nil, err
@@ -27,7 +25,6 @@ func NewNode(d driver.Driver, info []byte, version uint64) (*Node, error) {
 	ret := &Node{
 		OBM:      obm,
 		ConnInfo: info,
-		Version:  version,
 	}
 	copy(ret.CurrentToken[:], noToken[:])
 	return ret, nil

--- a/server_test.go
+++ b/server_test.go
@@ -148,12 +148,15 @@ func TestViewConsole(t *testing.T) {
 		)
 	}
 
+	// FIXME: the reasoning below is no longer sound, due to changes in the operation of the
+	// driver. We need to adjust this so it tests something actually valid.
+
 	// Clear out any buffered data:
 	bufReader.Discard(bufReader.Buffered())
 	// Now try to keep reading. The first of these *might* succeed, since the mock console
 	// goroutine may have made a call to write that we didn't match with a read before the
 	// server called Close(). But the second one should always fail; we should have been
-	// disconnected by the version bump, and the mock console goroutine should have seen
+	// disconnected by the revocation, and the mock console goroutine should have seen
 	// it on its next call to Write.
 	line, err := bufReader.ReadString('\n')
 	if err == nil {

--- a/server_test.go
+++ b/server_test.go
@@ -23,7 +23,7 @@ var adminRequests = []requestSpec{
 			"pass": "secret"
 		}
 	}`},
-	{"POST", "http://localhost:8080/node/somenode/console-endpoints", ""},
+	{"POST", "http://localhost:8080/node/somenode/token", ""},
 	{"DELETE", "http://localhost:8080/node/somenode", ""},
 	{"DELETE", "http://localhost:8080/node/somenode/token", ""},
 }
@@ -86,7 +86,7 @@ func TestViewConsole(t *testing.T) {
 			spec, status)
 	}
 	getToken := func() string {
-		req := (&requestSpec{"POST", "http://localhost/node/somenode/console-endpoints", ""}).toAdminAuth()
+		req := (&requestSpec{"POST", "http://localhost/node/somenode/token", ""}).toAdminAuth()
 		resp := httptest.NewRecorder()
 		handler.ServeHTTP(resp, req)
 		result := resp.Result()

--- a/server_test.go
+++ b/server_test.go
@@ -23,7 +23,7 @@ var adminRequests = []requestSpec{
 			"pass": "secret"
 		}
 	}`},
-	{"POST", "http://localhost:80080/node/somenode/console-endpoints", ""},
+	{"POST", "http://localhost:8080/node/somenode/console-endpoints", ""},
 	{"DELETE", "http://localhost:8080/node/somenode", ""},
 	{"DELETE", "http://localhost:8080/node/somenode/token", ""},
 }


### PR DESCRIPTION
Since we've redesigned the interaction between HIL and obmd, we don't need the somewhat complicated versioning mechanism. This patch simplifies the API.

The HIL spec we merged was vague enough wrt. how invalidation worked that I don't think this introduces anything that would need changing; it's meant to work with that design.

Note that this is built on top of #2, so it's got those commits in it as well.

//cc @naved001, @knikolla